### PR TITLE
Hack to fix LT-20339, Index out of bounds exception.

### DIFF
--- a/HermitCrab/Morpher.cs
+++ b/HermitCrab/Morpher.cs
@@ -197,6 +197,8 @@ namespace SIL.HermitCrab
 
 		private IEnumerable<Word> LexicalLookup(Word input)
 		{
+			if (input.ToString().Length == 0)
+				yield break;
 			if (_traceManager.IsTracing)
 				_traceManager.LexicalLookup(input.Stratum, input);
 			foreach (LexEntry entry in SearchRootAllomorphs(input.Stratum, input.Shape).Select(allo => allo.Morpheme).Cast<LexEntry>().Where(LexEntrySelector).Distinct())

--- a/HermitCrab/MorphologicalRules/AnalysisAffixProcessRule.cs
+++ b/HermitCrab/MorphologicalRules/AnalysisAffixProcessRule.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using SIL.Machine.Annotations;
@@ -34,6 +35,8 @@ namespace SIL.HermitCrab.MorphologicalRules
 
 		public IEnumerable<Word> Apply(Word input)
 		{
+			if (input.ToString().Length == 0)
+				return Enumerable.Empty<Word>();
 			if (!_morpher.RuleSelector(_rule))
 				return Enumerable.Empty<Word>();
 

--- a/HermitCrab/MorphologicalRules/AnalysisCompoundingRule.cs
+++ b/HermitCrab/MorphologicalRules/AnalysisCompoundingRule.cs
@@ -34,6 +34,8 @@ namespace SIL.HermitCrab.MorphologicalRules
 
 		public IEnumerable<Word> Apply(Word input)
 		{
+			if (input.ToString().Length == 0)
+				return Enumerable.Empty<Word>();
 			if (!_morpher.RuleSelector(_rule))
 				return Enumerable.Empty<Word>();
 

--- a/HermitCrab/Properties/AssemblyInfo.cs
+++ b/HermitCrab/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL")]
 [assembly: AssemblyProduct("HermitCrab")]
-[assembly: AssemblyCopyright("Copyright © 2008-2019 SIL International")]
+[assembly: AssemblyCopyright("Copyright © 2008-2021 SIL International")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.0")]

--- a/HermitCrab/RootAllomorphTrie.cs
+++ b/HermitCrab/RootAllomorphTrie.cs
@@ -62,6 +62,8 @@ namespace SIL.HermitCrab
 
 		public IEnumerable<RootAllomorph> Search(Shape shape)
 		{
+			if (shape.Count == 0)
+				yield break;
 			Annotation<ShapeNode> startAnn = shape.Annotations.GetFirst(_filter);
 			IEnumerable<FstResult<Shape, ShapeNode>> matches;
 			if (_fsa.Transduce(shape, startAnn, null, true, true, false, out matches))

--- a/HermitCrab/SynthesisStratumRule.cs
+++ b/HermitCrab/SynthesisStratumRule.cs
@@ -35,6 +35,9 @@ namespace SIL.HermitCrab
 
 		public IEnumerable<Word> Apply(Word input)
 		{
+			if (input.ToString().Length == 0)
+				return input.ToEnumerable();
+
 			if (!_morpher.RuleSelector(_stratum) || input.RootAllomorph.Morpheme.Stratum.Depth > _stratum.Depth)
 				return input.ToEnumerable();
 


### PR DESCRIPTION
The input word becomes empty after some rule application
which leads to the exception.
I could not determine why the input became blank.
This hack prevents the exception.